### PR TITLE
Configuration parameters for log format and prometheus

### DIFF
--- a/contrib/docker-compose/standalone/haproxy/etc/haproxy.d/50_fe_http_handler.cfg
+++ b/contrib/docker-compose/standalone/haproxy/etc/haproxy.d/50_fe_http_handler.cfg
@@ -164,7 +164,11 @@ frontend fe_http_handler
     .else
     use_backend be_acme_challenge  if acme_challenge !is_stopping
     .endif # HAP_DISABLE_CERTBOT
+    .if defined(HAP_DISABLE_PROMETHEUS)
+    .notice "Disabling prometheus front-end route"
+    .else
     use_backend be_prometheus      if get_prometheus !is_stopping
+    .endif
     #use_backend be_well_known_sec  if well_known_sec
 
     default_backend be_hockeypuck_rewrite

--- a/contrib/docker-compose/standalone/haproxy/etc/haproxy.d/50_fe_http_handler.cfg
+++ b/contrib/docker-compose/standalone/haproxy/etc/haproxy.d/50_fe_http_handler.cfg
@@ -145,7 +145,7 @@ frontend fe_http_handler
     option dontlognull
 
     log stdout format raw local0
-    log-format "%ci:%cp [%t] %ft %b/%s %Tq/%Tw/%Tc/%Tr/%Tt %ST %U/%B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %hr %hs %{+Q}r"
+    log-format "${HAP_LOG_FORMAT}"
 
     # X-Forward- settings
     http-request    set-header X-Forwarded-Proto http  if !{ ssl_fc }

--- a/contrib/docker-compose/standalone/haproxy/etc/haproxy.d/60_fe_hockeypuck_ddos_lb.cfg
+++ b/contrib/docker-compose/standalone/haproxy/etc/haproxy.d/60_fe_hockeypuck_ddos_lb.cfg
@@ -77,7 +77,7 @@ frontend fe_hockeypuck_ddos_lb
     option dontlognull
 
     log stdout format raw local1
-    log-format "%ci:%cp [%t] %ft %b/%s %Tq/%Tw/%Tc/%Tr/%Tt %ST %U/%B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %hr %hs %{+Q}r"
+    log-format "${HAP_LOG_FORMAT}"
 
     # Fetch stats from the primary Hockeypuck instance
     use_backend be_hockeypuck_primary if keyserver_host get_pks_lookup pks_op_stats METH_GET

--- a/contrib/docker-compose/standalone/haproxy/etc/haproxy.d/70_fe_prometheus.cfg
+++ b/contrib/docker-compose/standalone/haproxy/etc/haproxy.d/70_fe_prometheus.cfg
@@ -1,6 +1,10 @@
+.if defined(HAP_DISABLE_PROMETHEUS)
+.notice "Disabling prometheus front-end route"
+.else
 # Frontend to export stats to prometheus
 frontend fe_prometheus
     bind :8405
     mode http
     http-request use-service prometheus-exporter
     no log
+.endif

--- a/contrib/docker-compose/standalone/haproxy/etc/haproxy.d/80_be.cfg
+++ b/contrib/docker-compose/standalone/haproxy/etc/haproxy.d/80_be.cfg
@@ -40,6 +40,9 @@ backend be_tarpit
 
     http-request tarpit
 
+.if defined(HAP_DISABLE_PROMETHEUS)
+.notice "Disabling prometheus backend"
+.else
 # Backend to prometheus web interface
 backend be_prometheus
     mode http
@@ -53,6 +56,7 @@ backend be_prometheus
     # ~~ End of URL rewriting rules ~~
 
     server prometheus "${PROMETHEUS_HOST_PORT}" maxconn 20
+.endif
 
 # Backend to apply request and response rewriting rules
 backend be_hockeypuck_rewrite

--- a/contrib/docker-compose/standalone/mksite.bash
+++ b/contrib/docker-compose/standalone/mksite.bash
@@ -64,6 +64,8 @@ TOR_EXIT_RELAYS_URL="https://www.dan.me.uk/torlist/?exit"
 
 # Set this to the host:port that your HAProxy peers will see
 #HAP_PEER_HOST_PORT=127.0.0.1:1395
+# Set the HAProxy log format
+HAP_LOG_FORMAT="%ci:%cp [%t] %ft %b/%s %Tq/%Tw/%Tc/%Tr/%Tt %ST %U/%B %CC %CS %tsc %ac/%fc/%bc/%sc/%rc %sq/%bq %hr %hs %{+Q}r"
 
 # Set these to "port" or "host:port" to override the listening hostip/port(s)
 #HAP_HTTP_HOST_PORT=80

--- a/contrib/docker-compose/standalone/mksite.bash
+++ b/contrib/docker-compose/standalone/mksite.bash
@@ -80,6 +80,11 @@ HAP_LOG_FORMAT="%ci:%cp [%t] %ft %b/%s %Tq/%Tw/%Tc/%Tr/%Tt %ST %U/%B %CC %CS %ts
 # Trust X-Forwarded-For: headers
 #HAP_BEHIND_PROXY=true
 
+# Set to any value to disable the service
+#HAP_DISABLE_SSL=true
+#HAP_DISABLE_CERTBOT=true
+#HAP_DISABLE_PROMETHEUS=true
+
 # Set this to e.g. /etc/letsencrypt in order to share certificates with the host.
 # Note that the certbot container is responsible for renewing these.
 #CERTBOT_CONF=certbot_conf


### PR DESCRIPTION
Add a parameter to define the log format
and an option to disable prometheus

untested, as it turned out my haproxy is too old to use this syntax. Maybe I can use it in the future